### PR TITLE
Support all verification algorithms

### DIFF
--- a/transports/tls-quic/Cargo.toml
+++ b/transports/tls-quic/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 libp2p-core = { path = "../../core", version = "0.29.0" }
 rcgen = "0.8.11"
-x509-parser = { version = "0.9.2", features = ["verify"] }
+x509-parser = "0.9.2"
 der-parser = { version = "5.1.0", features = ["serialize"] }
 yasna = "0.4.0"
+rustls = "0.19.1"
+ring = "0.16.20"

--- a/transports/tls-quic/src/certificate.rs
+++ b/transports/tls-quic/src/certificate.rs
@@ -215,8 +215,8 @@ impl P2pCertificate<'_> {
             // self-signature is not valid.
             let raw_certificate = self.certificate.tbs_certificate.as_ref();
             let signature = self.certificate.signature_value.data;
-            let self_signed = self.check_signature(signature_scheme, raw_certificate, signature);
-            if !self_signed {
+            // check if self signed
+            if !self.verify_signature(signature_scheme, raw_certificate, signature) {
                 return false
             }
         } else {
@@ -411,7 +411,7 @@ impl P2pCertificate<'_> {
     }
     /// Verify the `signature` of the `message` signed by the private key corresponding to the public key stored
     /// in the certificate.
-    pub fn check_signature(
+    pub fn verify_signature(
         &self, signature_scheme: rustls::SignatureScheme, message: &[u8], signature: &[u8],
     ) -> bool {
         if let Some(pk) = self.public_key(signature_scheme) {


### PR DESCRIPTION
So far implemented and tested:

| Alg | Parse x509 | Verify signature |
| --- | --- | --- |
| RSA_PKCS1_SHA256|yes|yes|
| RSA_PKCS1_SHA384|yes|yes|
| RSA_PKCS1_SHA512|yes|yes|
| ECDSA_NISTP256_SHA256|yes|yes|
| ECDSA_NISTP384_SHA384|yes|yes|
| ECDSA_NISTP521_SHA512|yes|not supported in `ring`|
| RSA_PSS_SHA256|yes|yes|
| RSA_PSS_SHA384|yes|yes|
| RSA_PSS_SHA512|yes|yes|
| ED25519|yes|yes|
| ED448|yes|not supported in `ring`|

Fixes https://github.com/kpp/rust-libp2p/issues/2