### PR TITLE
 fix(quic): use Provider::send_to for UDP datagram

### DIFF
--- a/transports/quic/src/hole_punching.rs
+++ b/transports/quic/src/hole_punching.rs
@@ -23,11 +23,6 @@ pub(crate) async fn hole_puncher<P: Provider>(
 }
 
 async fn punch_holes<P: Provider>(socket: UdpSocket, remote_addr: SocketAddr) -> Error {
-    let socket = match P::from_std_udp_socket(socket) {
-        Ok(s) => s,
-        Err(e) => return Error::Io(e),
-    };
-
     loop {
         let sleep_duration = Duration::from_millis(rand::thread_rng().gen_range(10..=200));
         P::sleep(sleep_duration).await;

--- a/transports/quic/src/provider.rs
+++ b/transports/quic/src/provider.rs
@@ -22,7 +22,7 @@ use futures::{future::BoxFuture, Future};
 use if_watch::IfEvent;
 use std::{
     io,
-    net::SocketAddr,
+    net::{SocketAddr, UdpSocket},
     task::{Context, Poll},
     time::Duration,
 };
@@ -43,7 +43,6 @@ pub enum Runtime {
 /// Provider for a corresponding quinn runtime and spawning tasks.
 pub trait Provider: Unpin + Send + Sized + 'static {
     type IfWatcher: Unpin + Send;
-    type UdpSocket: Unpin + Send + Sync;
 
     /// Run the corresponding runtime
     fn runtime() -> Runtime;
@@ -65,12 +64,9 @@ pub trait Provider: Unpin + Send + Sized + 'static {
     /// Sleep for specified amount of time.
     fn sleep(duration: Duration) -> BoxFuture<'static, ()>;
 
-    /// Creates new UdpSocket from a previously bound std::net::UdpSocket.
-    fn from_std_udp_socket(socket: std::net::UdpSocket) -> io::Result<Self::UdpSocket>;
-
     /// Sends data on the socket to the given address. On success, returns the number of bytes written.
     fn send_to<'a>(
-        udp_socket: &'a Self::UdpSocket,
+        udp_socket: &'a UdpSocket,
         buf: &'a [u8],
         target: SocketAddr,
     ) -> BoxFuture<'a, io::Result<usize>>;

--- a/transports/quic/src/provider/async_std.rs
+++ b/transports/quic/src/provider/async_std.rs
@@ -36,6 +36,7 @@ pub struct Provider;
 
 impl super::Provider for Provider {
     type IfWatcher = if_watch::smol::IfWatcher;
+    type UdpSocket = async_std::net::UdpSocket;
 
     fn runtime() -> super::Runtime {
         super::Runtime::AsyncStd
@@ -58,5 +59,17 @@ impl super::Provider for Provider {
 
     fn sleep(duration: Duration) -> BoxFuture<'static, ()> {
         async_std::task::sleep(duration).boxed()
+    }
+
+    fn from_std_udp_socket(socket: std::net::UdpSocket) -> io::Result<Self::UdpSocket> {
+        Ok(socket.into())
+    }
+
+    fn send_to<'a>(
+        udp_socket: &'a Self::UdpSocket,
+        buf: &'a [u8],
+        target: std::net::SocketAddr,
+    ) -> BoxFuture<'a, io::Result<usize>> {
+        udp_socket.send_to(buf, target).boxed()
     }
 }

--- a/transports/quic/src/provider/tokio.rs
+++ b/transports/quic/src/provider/tokio.rs
@@ -21,7 +21,7 @@
 use futures::{future::BoxFuture, Future, FutureExt};
 use std::{
     io,
-    net::SocketAddr,
+    net::{SocketAddr, UdpSocket},
     task::{Context, Poll},
     time::Duration,
 };
@@ -36,7 +36,6 @@ pub struct Provider;
 
 impl super::Provider for Provider {
     type IfWatcher = if_watch::tokio::IfWatcher;
-    type UdpSocket = tokio::net::UdpSocket;
 
     fn runtime() -> super::Runtime {
         super::Runtime::Tokio
@@ -61,15 +60,15 @@ impl super::Provider for Provider {
         tokio::time::sleep(duration).boxed()
     }
 
-    fn from_std_udp_socket(socket: std::net::UdpSocket) -> io::Result<Self::UdpSocket> {
-        tokio::net::UdpSocket::from_std(socket)
-    }
-
     fn send_to<'a>(
-        udp_socket: &'a Self::UdpSocket,
+        udp_socket: &'a UdpSocket,
         buf: &'a [u8],
         target: SocketAddr,
     ) -> BoxFuture<'a, io::Result<usize>> {
-        udp_socket.send_to(buf, target).boxed()
+        Box::pin(async move {
+            tokio::net::UdpSocket::from_std(udp_socket.try_clone()?)?
+                .send_to(buf, target)
+                .await
+        })
     }
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Addresses https://github.com/libp2p/rust-libp2p/pull/3454#discussion_r1236859831.

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
